### PR TITLE
Allow upstreams to have multiple servers for load balancing

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,6 +106,15 @@ func runSignal() error {
 }
 
 func writeConfig(params []*container) error {
+	var containers map[string][]*container
+	containers = make(map[string][]*container);
+	// Remap the containers as a 2D array with the domain as the index
+	for _, v := range params {
+		if _, ok := containers[v.Host]; !ok {
+			containers[v.Host] = make([]*container, 0)
+		}
+		containers[v.Host] = append(containers[v.Host], v)
+	}
 	tmpl, err := template.ParseFiles(*templateFile)
 	if err != nil {
 		return err
@@ -115,7 +124,7 @@ func writeConfig(params []*container) error {
 		return err
 	}
 	defer f.Close()
-	return tmpl.Execute(f, params)
+	return tmpl.Execute(f, containers)
 }
 
 func findClusterName() (*string, error) {

--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -9,16 +9,18 @@ server {
         return 503;
 }
 
-{{ range $index, $value := . }}
-upstream {{ $value.Host }} {
+{{ range $domain, $container := . }}
+upstream {{ $domain }} {
+    {{ range $_, $value := $container }}
          server {{ $value.Address }}:{{ $value.Port }};
+    {{ end }}
 }
 server {
-        server_name {{ $value.Host }};
+        server_name {{ $domain }};
         listen 80;
         access_log /var/log/nginx/access.log vhost;
         location / {
-                proxy_pass http://{{ $value.Host }};
+                proxy_pass http://{{ $domain }};
         }
 }
 {{ end }}


### PR DESCRIPTION
Fixes the limitation of one ECS task per virtual host. Config template also updated at https://github.com/codesuki/ecs-nginx-proxy/pull/2