### PR TITLE
Allow for configuration of which environment variable to search for

### DIFF
--- a/main.go
+++ b/main.go
@@ -39,6 +39,7 @@ var (
 	templateFile = app.Flag("template", "Path to template file.").Short('t').Required().ExistingFile()
 	outputFile   = app.Flag("output", "Path to output file.").Short('o').Required().String()
 	taskName     = app.Flag("task", "Name of ECS task containing nginx.").Default("ecs-nginx-proxy").String()
+	hostVar      = app.Flag("host-var", "Which ENV var to use for the hostname.").Default("virtual_host").String()
 
 	signal = app.Flag("signal", "Command to run to signal change.").Short('s').Default("nginx -s reload").String()
 
@@ -92,7 +93,7 @@ func execute(ec2 *ec2Client, ecs *ecsClient) {
 }
 
 func updateAndWrite(ec2 *ec2Client, ecs *ecsClient) {
-	containers, err := newScanner(*cluster, ec2, ecs).scan()
+	containers, err := newScanner(*cluster, *hostVar, ec2, ecs).scan()
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
> _Apologies in advance - I'm entirely unfamiliar with Go, this is my first foray, so if I've done something dumb feel free to point it out as a learning opportunity 😉._
>
> _If you hate this or just don't see the use case for it I won't be offended if you just close this PR, but I thought I should at least offer back the changes I made in case you or someone else finds it helpful._

I found myself with the need to run two load balancers pointing to the same ECS cluster, but servicing different services through separate reverse proxies (internal vs. external). While another way to get around this would be to create more than one cluster we found it more efficient to utilize the resources of one cluster ... What that meant was we needed a way to tell the reverse proxy which containers to pay attention to, without them both proxying the same containers. I've created a fork of `ecs-nginx-proxy` as well which uses my version of `ecs-gen` and pushed to docker hub [here](https://hub.docker.com/r/pvermeyden/ecs-nginx-proxy/) in case you wanted to test it out.

This PR gives the ability to specify (via the command line or by environment variable) which environment variable to search container definitions for to use as the hostname. It defaults to `virtual_host` (the current behaviour).

While this doesn't quite address the question in #10 - it does allow the use of a differently named environment variable.