### PR TITLE
Extend Container structure to expose all container environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ type Container struct {
     Host    string // VIRTUAL_HOST environment variable
     Port    string
     Address string
+    Env     map[string]string
 }
 ```
 

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -112,6 +114,15 @@ func runSignal() error {
 	return err
 }
 
+func newTemplate(name string) *template.Template {
+	tmpl := template.New(name).Funcs(template.FuncMap{
+		"replace":                strings.Replace,
+		"split":                  strings.Split,
+		"splitN":                 strings.SplitN,
+	})
+	return tmpl
+}
+
 func writeConfig(params []*container) error {
 	var containers map[string][]*container
 	containers = make(map[string][]*container);
@@ -122,7 +133,7 @@ func writeConfig(params []*container) error {
 		}
 		containers[v.Host] = append(containers[v.Host], v)
 	}
-	tmpl, err := template.ParseFiles(*templateFile)
+	tmpl, err := newTemplate(filepath.Base(*templateFile)).ParseFiles(*templateFile)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -19,6 +19,7 @@ type container struct {
 	Host    string
 	Port    string
 	Address string
+	Env     map[string]string
 }
 
 type metadata struct {


### PR DESCRIPTION
This pull request will make all container variables accessible from template through `.Env` map
Also it extends basic templating functionality with a couple of string functions:
* *`replace $string $old $new $count`*: Replaces up to `$count` occurences of `$old` with `$new` in `$string`. Alias for [`strings.Replace`](http://golang.org/pkg/strings/#Replace)
* *`split $string $sep`*: Splits `$string` into a slice of substrings delimited by `$sep`. Alias for [`strings.Split`](http://golang.org/pkg/strings/#Split)
* *`splitN $string $sep $count`*: Splits `$string` into a slice of substrings delimited by `$sep`, with number of substrings returned determined by `$count`. Alias for [`strings.SplitN`](https://golang.org/pkg/strings/#SplitN)

Pretty much all extended functionality replicates original [docker-gen](https://github.com/jwilder/docker-gen) behaviour.