### PR TITLE
Allow for multiple domains by using a name for upstream

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 )
 
 type container struct {
+	Name    string
 	Host    string
 	Port    string
 	Address string
@@ -153,10 +154,10 @@ func writeConfig(params []*container) error {
 	containers = make(map[string][]*container)
 	// Remap the containers as a 2D array with the domain as the index
 	for _, v := range params {
-		if _, ok := containers[v.Host]; !ok {
-			containers[v.Host] = make([]*container, 0)
+		if _, ok := containers[v.Name]; !ok {
+			containers[v.Name] = make([]*container, 0)
 		}
-		containers[v.Host] = append(containers[v.Host], v)
+		containers[v.Name] = append(containers[v.Name], v)
 	}
 	tmpl, err := newTemplate(filepath.Base(*templateFile)).ParseFiles(*templateFile)
 	if err != nil {

--- a/scanner.go
+++ b/scanner.go
@@ -124,6 +124,7 @@ func (s *scanner) extractContainer(t *ecs.Task, cd *ecs.ContainerDefinition) (*c
 		return nil, errors.New("[" + *cd.Name + "] no valid port configuration found. skipping")
 	}
 	return &container{
+		Name:    strings.Fields(virtualHost)[0],
 		Host:    virtualHost,
 		Port:    port,
 		Env:     envVariables,

--- a/templates/nginx.tmpl
+++ b/templates/nginx.tmpl
@@ -9,18 +9,18 @@ server {
         return 503;
 }
 
-{{ range $domain, $container := . }}
-upstream {{ $domain }} {
+{{ range $name, $container := . }}
+upstream {{ $name }} {
     {{ range $_, $value := $container }}
          server {{ $value.Address }}:{{ $value.Port }};
     {{ end }}
 }
 server {
-        server_name {{ $domain }};
+        server_name {{ (index $container 0).Host }};
         listen 80;
         access_log /var/log/nginx/access.log vhost;
         location / {
-                proxy_pass http://{{ $domain }};
+                proxy_pass http://{{ $name }};
         }
 }
 {{ end }}


### PR DESCRIPTION
#### Motivation:
The idea behind this request was to allow multiple domains to route to the same task - (for instance, two spelling variations of a sub-domain). Rather than having two task definitions, it'd be nicer to have a single task definition listen to more than one server name.

#### Changes needed:
The problem is the best way to specify the above use case in Nginx is by specifying all the applicable server names split by whitespace. However, we also use this field for the upstream name and proxy_pass fields, which do not take more than a single argument...

I had considered using something like the ecsTask.Group string for the name field instead, but I believe that such an approach would be unwise as there may be several container definitions within that grouping that require different server names. By utilizing the first host in the virtualHost variable it allows us to group together only those services that share that virtualHost. I believe it to be far less likely that an individual will have a valid use case for using the same virtualHost within two separate task definitions.

I have also updated the sample nginx.tmpl file - and will be submitting a separate PR against the ecs-nginx-proxy repository with the same changes, linking to this PR for the reasoning.

#### Regex support:
This also allows for regex domain matching, if desired. You'd want to specify a static domain first so that it gets used for the upstream name, but then the remaining server_names can be a regex pattern (probably in quotes, to be safe).