### PR TITLE
level based logging

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+type localLog struct {
+	infoLog    *log.Logger
+	warningLog *log.Logger
+	errorLog   *log.Logger
+	fatalLog   *log.Logger
+}
+
+const defaultFlags = log.Ltime
+
+const (
+	levelInfo  = "info"
+	levelWarn  = "warn"
+	levelError = "error"
+)
+
+func newLogger(level string) *localLog {
+	//fatal will always output to stderr no matter the logLevel
+	infoWriter := ioutil.Discard
+	warnWriter := ioutil.Discard
+	errorWriter := ioutil.Discard
+	fatalWriter := os.Stderr
+
+	switch level {
+	case levelInfo:
+		infoWriter = os.Stdout
+		fallthrough
+	case levelWarn:
+		warnWriter = os.Stdout
+		fallthrough
+	case levelError:
+		errorWriter = os.Stderr
+	}
+
+	Logger := localLog{
+		infoLog:    log.New(infoWriter, "[INFO]\t", defaultFlags),
+		warningLog: log.New(warnWriter, "[WARN]\t", defaultFlags),
+		errorLog:   log.New(errorWriter, "[ERROR]\t", defaultFlags),
+		fatalLog:   log.New(fatalWriter, "[FATAL]\t", defaultFlags),
+	}
+	return &Logger
+}
+
+func (l *localLog) Info(message ...string) {
+	l.infoLog.Print(message)
+}
+
+func (l *localLog) Warning(message ...string) {
+	l.warningLog.Print(message)
+}
+
+func (l *localLog) Error(err error) {
+	l.errorLog.Print(err.Error())
+}
+
+func (l *localLog) Fatal(message ...string) {
+	l.fatalLog.Fatal(message)
+}

--- a/log.go
+++ b/log.go
@@ -48,18 +48,18 @@ func newLogger(level string) *localLog {
 	return &Logger
 }
 
-func (l *localLog) Info(message ...string) {
-	l.infoLog.Print(message)
+func (l *localLog) Info(format string, v ...interface{}) {
+	l.infoLog.Printf(format, v...)
 }
 
-func (l *localLog) Warning(message ...string) {
-	l.warningLog.Print(message)
+func (l *localLog) Warning(format string, v ...interface{}) {
+	l.warningLog.Printf(format, v...)
 }
 
-func (l *localLog) Error(err error) {
-	l.errorLog.Print(err.Error())
+func (l *localLog) Error(v ...interface{}) {
+	l.errorLog.Print(v...)
 }
 
-func (l *localLog) Fatal(message ...string) {
-	l.fatalLog.Fatal(message)
+func (l *localLog) Fatal(format string, v ...interface{}) {
+	l.fatalLog.Fatalf(format, v...)
 }

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func checkClusterFlag() {
 		if err != nil || *cluster == "" {
 			logger.Fatal("could not determine cluster name. please define using --cluster / -c")
 		}
-		logger.Info("found cluster name to be:", *cluster)
+		logger.Info("found cluster name to be: %s", *cluster)
 	}
 }
 
@@ -103,7 +103,7 @@ func checkRegionFlag(meta *ec2Meta) {
 			logger.Fatal("could not determine cluster region. please define using --region / -r")
 		}
 		*region = r
-		logger.Info("found cluster region to be:", *region)
+		logger.Info("found cluster region to be: %s", *region)
 	}
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	"log"
 	"strconv"
 	"strings"
 
@@ -26,7 +25,7 @@ func newScanner(cluster string, hostVar string, ec2 *ec2Client, ecs *ecsClient) 
 }
 
 func (s *scanner) scan() ([]*container, error) {
-	log.Println("updating config")
+	logger.Info("updating config")
 	clusterInfo, err := s.ecs.describeCluster(s.cluster)
 	if err != nil {
 		return nil, err
@@ -86,7 +85,7 @@ func (s *scanner) extractContainers() ([]*container, error) {
 		for _, cd := range taskDefinition.ContainerDefinitions {
 			container, err := s.extractContainer(t, cd)
 			if err != nil {
-				log.Println(err)
+				logger.Error(err)
 				continue
 			}
 			containers = append(containers, container)


### PR DESCRIPTION
This change introduces a new command line flag to add logging levels (``info``, ``warn``, ``error``)

No matter the logging level selected ``fatal`` will always write to stderr.

I had considered using a library for this, but I can appreciate you wanting to keep dependencies to a minimum - particularly when nothing fancy is needed anyway.

input sanitation is provided out of box by Kingpin, but if for some reason a non valid logging level is set - it will just default to error.